### PR TITLE
allow re-use of OpenOptions in other crates

### DIFF
--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -15,6 +15,7 @@ pub use file::File;
 
 mod open_options;
 pub use open_options::OpenOptions;
+pub use open_options::OpenOptionsIoUringExt;
 
 mod statx;
 pub use statx::is_dir_regfile;

--- a/src/fs/open_options.rs
+++ b/src/fs/open_options.rs
@@ -389,3 +389,33 @@ impl OpenOptionsExt for OpenOptions {
         self
     }
 }
+
+/// Extension trait to allow re-use of [`OpenOptions`] in other crates that
+/// build on top of [`io_uring`].
+pub trait OpenOptionsIoUringExt {
+    /// Turn `self` into an [`::io_uring::opcode::OpenAt`] SQE for the given `path`.
+    ///
+    ///
+    /// # Safety
+    ///
+    /// The returned SQE stores the provided `path` pointer.
+    /// The caller must ensure that it remains valid until either the returned
+    /// SQE is dropped without being submitted, or if the SQE is submitted until
+    /// the corresponding completion is observed.
+    unsafe fn as_openat_sqe(&self, path: *const u8) -> io::Result<io_uring::squeue::Entry>;
+}
+
+impl OpenOptionsIoUringExt for OpenOptions {
+    unsafe fn as_openat_sqe(&self, path: *const u8) -> io::Result<io_uring::squeue::Entry> {
+        use io_uring::{opcode, types};
+        let flags = libc::O_CLOEXEC
+            | self.access_mode()?
+            | self.creation_mode()?
+            | (self.custom_flags & !libc::O_ACCMODE);
+
+        Ok(opcode::OpenAt::new(types::Fd(libc::AT_FDCWD), path)
+            .flags(flags)
+            .mode(self.mode)
+            .build())
+    }
+}

--- a/src/io/open.rs
+++ b/src/io/open.rs
@@ -11,33 +11,23 @@ use std::path::Path;
 #[allow(dead_code)]
 pub(crate) struct Open {
     pub(crate) path: CString,
-    pub(crate) flags: libc::c_int,
 }
 
 impl Op<Open> {
     /// Submit a request to open a file.
     pub(crate) fn open(path: &Path, options: &OpenOptions) -> io::Result<Op<Open>> {
-        use io_uring::{opcode, types};
         let path = super::util::cstr(path)?;
-        let flags = libc::O_CLOEXEC
-            | options.access_mode()?
-            | options.creation_mode()?
-            | (options.custom_flags & !libc::O_ACCMODE);
-
+        // Get a reference to the memory. The string will be held by the
+        // operation state and will not be accessed again until the operation
+        // completes.
+        let sqe = unsafe {
+            let p_ref = path.as_c_str().as_ptr();
+            crate::fs::OpenOptionsIoUringExt::as_openat_sqe(options, p_ref)?
+        };
         CONTEXT.with(|x| {
             x.handle()
                 .expect("Not in a runtime context")
-                .submit_op(Open { path, flags }, |open| {
-                    // Get a reference to the memory. The string will be held by the
-                    // operation state and will not be accessed again until the operation
-                    // completes.
-                    let p_ref = open.path.as_c_str().as_ptr();
-
-                    opcode::OpenAt::new(types::Fd(libc::AT_FDCWD), p_ref)
-                        .flags(flags)
-                        .mode(options.mode)
-                        .build()
-                })
+                .submit_op(Open { path }, move |_| sqe)
         })
     }
 }


### PR DESCRIPTION
The `OpenOptions` struct's functionality of mapping the builder pattern APIs to libc-level flags flags is useful outside of `tokio-uring`.

Our particular use case is an alternative approach to tokio + io_uring which will be open-sourced soon. We are already re-using the `IoBuf` trait there, so, it makes sense to also re-use `OpenOptions`.

So, this PR adds an extension trait for `OpenOptions` that allows producing an `io_uring::squeue::Entry`.